### PR TITLE
add changes to meta.yaml

### DIFF
--- a/recipe/install_base.sh
+++ b/recipe/install_base.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-
-python -m pip install --no-deps --ignore-installed -vv .
+version=2.6.0
+python -m pip install -vv keras-$version-py2.py3-none-any.whl

--- a/recipe/install_base.sh
+++ b/recipe/install_base.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-version=2.6.0
-python -m pip install -vv keras-$version-py2.py3-none-any.whl
+python -m pip install -vv keras-$PKG_VERSION-py2.py3-none-any.whl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,8 +52,9 @@ outputs:
         # - keras.wrappers
 
   - name: keras
+    script: install_base.sh  # [not win]
+    script: install_base.bat # [win]
     build:
-      script: python -m pip install -vv keras-{{ version }}-py2.py3-none-any.whl
       noarch: true
     requirements:
       host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ outputs:
     script: install_base.sh  # [not win]
     script: install_base.bat  # [win]
     build:
-      noarch: true
+      noarch: python
     requirements:
       host:
         - python >=3.6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,17 @@
-{% set version = "2.4.3" %}
+{% set version = "2.6.0" %}
 
 package:
   name: keras_split
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/K/Keras/Keras-{{ version }}.tar.gz
-  sha256: fedd729b52572fb108a98e3d97e1bac10a81d3917d2103cc20ab2a5f03beb973
+  - url: https://pypi.io/packages/py2.py3/k/keras/keras-{{ version }}-py2.py3-none-any.whl
+    sha256: 504af5656a9829fe803ce48a8580ef16916e89906aceddad9e098614269437e7
+  - url: https://raw.githubusercontent.com/keras-team/keras/v{{ version }}/LICENSE
+    sha256: ebc07b279109d4bd5e58fe06f54e8f8aee8ba1024b77b222bc04214ae6f56348
 
 build:
+  noarch: python
   number: 0
 
 outputs:
@@ -18,38 +21,53 @@ outputs:
     build:
       noarch: python
     requirements:
-      build:
+      host:
         - python >=3.6
         - pip
       run:
         - python >=3.6
-        - numpy >=1.9.1
-        - scipy >=0.14
-        - pyyaml
-        - h5py
-        - tensorflow >=2.2
+        # - numpy >=1.9.1
+        # - scipy >=0.14
+        # - pyyaml
+        # - h5py
+        # - tensorflow >=2.2
       # add run_constrained to prevent installation of mismatched keras and
       # keras-base packages
       run_constrained:
-        - keras {{ version }}
+        # - keras {{ version }}
+        - tensorflow {{ version }}
     test:
-      imports:
-        - keras
-        - keras.backend
-        - keras.datasets
-        - keras.engine
-        - keras.layers
-        - keras.preprocessing
-        - keras.utils
-        - keras.wrappers
+      requires:
+        - pip
+      commands:
+        - pip check
+      # imports:
+        # - keras
+        # - keras.backend
+        # - keras.datasets
+        # - keras.engine
+        # - keras.layers
+        # - keras.preprocessing
+        # - keras.utils
+        # - keras.wrappers
 
   - name: keras
     build:
+      script: python -m pip install -vv keras-{{ version }}-py2.py3-none-any.whl
       noarch: true
     requirements:
+      host:
+        - python >=3.6
+        - pip
       run:
-        - keras-base {{ version }}
-        - tensorflow
+        - python >=3.6
+      run_constrained:
+        - tensorflow {{ version }}
+    test:
+      requires:
+        - pip
+      commands:
+        - pip check
     about:
       home: https://github.com/fchollet/keras
       license: MIT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ outputs:
         - scipy >=0.14
         - pyyaml
         - h5py
-        - tensorflow >=2.0.0  
+        - tensorflow {{ version }}  
       # add run_constrained to prevent installation of mismatched keras and
       # keras-base packages
       run_constrained:
@@ -66,7 +66,7 @@ outputs:
       run:
         - python >=3.6
       run_constrained:
-        - tensorflow >=2.0.0
+        - tensorflow {{ version }}
     test:
       requires:
         - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,7 @@ outputs:
         - keras.preprocessing
         - keras.utils
         - keras.wrappers
-
+ #some of the imports are commented out during testing to avoid circular dependencies
   - name: keras
     script: install_base.sh  # [not win]
     script: install_base.bat  # [win]
@@ -65,8 +65,6 @@ outputs:
         - wheel
       run:
         - python >=3.6
-      run_constrained:
-        - tensorflow
     test:
       requires:
         - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ outputs:
         - scipy >=0.14
         - pyyaml
         - h5py
-        - tensorflow {{ version }}  
+        - tensorflow >=2.0.0  
       # add run_constrained to prevent installation of mismatched keras and
       # keras-base packages
       run_constrained:
@@ -66,7 +66,7 @@ outputs:
       run:
         - python >=3.6
       run_constrained:
-        - tensorflow {{ version }}
+        - tensorflow >=2.0.0
     test:
       requires:
         - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,53 +17,56 @@ build:
 outputs:
   - name: keras-base
     script: install_base.sh  # [not win]
-    script: install_base.bat # [win]
+    script: install_base.bat  # [win]
     build:
       noarch: python
     requirements:
       host:
         - python >=3.6
         - pip
+        - setuptools
+        - wheel
       run:
         - python >=3.6
-        # - numpy >=1.9.1
-        # - scipy >=0.14
-        # - pyyaml
-        # - h5py
-        # - tensorflow >=2.2
+        - numpy >=1.9.1
+        - scipy >=0.14
+        - pyyaml
+        - h5py
+        - tensorflow  
       # add run_constrained to prevent installation of mismatched keras and
       # keras-base packages
       run_constrained:
-        # - keras {{ version }}
-        - tensorflow {{ version }}
+        - keras {{ version }}
     test:
       requires:
         - pip
       commands:
         - pip check
-      # imports:
-        # - keras
-        # - keras.backend
-        # - keras.datasets
-        # - keras.engine
-        # - keras.layers
-        # - keras.preprocessing
-        # - keras.utils
-        # - keras.wrappers
+      imports:
+        - keras
+        - keras.backend
+        - keras.datasets
+        - keras.engine
+        - keras.layers
+        - keras.preprocessing
+        - keras.utils
+        - keras.wrappers
 
   - name: keras
     script: install_base.sh  # [not win]
-    script: install_base.bat # [win]
+    script: install_base.bat  # [win]
     build:
       noarch: true
     requirements:
       host:
         - python >=3.6
         - pip
+        - setuptools
+        - wheel
       run:
         - python >=3.6
       run_constrained:
-        - tensorflow {{ version }}
+        - tensorflow
     test:
       requires:
         - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ outputs:
         - scipy >=0.14
         - pyyaml
         - h5py
-        - tensorflow  
+        - tensorflow {{ version }}  
       # add run_constrained to prevent installation of mismatched keras and
       # keras-base packages
       run_constrained:
@@ -65,6 +65,8 @@ outputs:
         - wheel
       run:
         - python >=3.6
+      run_constrained:
+        - tensorflow {{ version }}
     test:
       requires:
         - pip


### PR DESCRIPTION
1. check the upstream
2. check the pinnings
https://github.com/keras-team/keras/blob/master/BUILD
https://github.com/keras-team/keras/blob/master/README.md
https://github.com/keras-team/keras/blob/master/keras/testing_utils.py
https://github.com/keras-team/keras/blob/master/keras/regularizers.py
https://github.com/keras-team/keras/blob/master/keras/optimizers.py
https://github.com/keras-team/keras/blob/master/keras/keras.bzl
https://github.com/keras-team/keras/blob/master/keras/backend_config.py

3. check changelogs
https://github.com/keras-team/keras/releases/tag/v2.6.0
https://github.com/keras-team/keras/blob/master/README.md

There was no changelog documentation, so the release information was reviewed instead. 
There were no significant open issues mentioned on the release section. 

4. additional research
https://github.com/conda-forge/keras-feedstock/issues

There are some issues with the new version of Keras closing the prompt, 
However the issues seems to be resolved by reinstalling the application

https://github.com/conda-forge/keras-feedstock/issues/36

There is also the issue of the shell loading slow, for some users
https://github.com/conda-forge/keras-feedstock/issues/45

Since the issue seems to be with only a few users it might not be an extreme issue but we propably shouod keeep an eye on these two issues. 

5. verify dev_url
6. verify doc_url
7. verify pip to the test section
9. verify the test section
10. additional tests

The following test was conducted for the `keras` package
`conda build keras-feedstock --test`
the test result was the following:
`All tests passed`


In addition, the `keras` package was tested using the `efficientnet` package. 
First a working version of `efficientnet` was built, then the dependency for `keras` version `2.6.0` as updated on the `efficientnet` `meta.yaml` file. 
Then the following test was run for testing:
`conda build efficientnet-pytorch-feedstock --test`
The result was as following:
`All tests passed`

Base on the research and test results we can conclude that it is relatively safe to update `keras` to version `2.6.0`, however we must keep an eye out in the rare cases where users might have issues. We also must keep an eye out for new versions solving some of the rare open issues. 
