### PR TITLE
Pkg 5458

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @croth1 @ericdill @jjhelmus @mariusvniekerk @ocefpaf

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/optree-feedstock/pr1/ecac75e

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/optree-feedstock/pr1/ecac75e

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,12 +47,24 @@ requirements:
     - torchvision >=0.16.0
 
 test:
+  source_files:
+    - conftest.py
+    - pyproject.toml
+    - integration_tests
   requires:
     - pip
     - jax  # [not (win or s390x)]
     - pytorch
+    - pytest
   commands:
     - pip check
+    # numpy is checked as backend in exports and contest (pytest tests configuration)
+    # although not listed in the README among the backends. We add a quick test here.
+    #
+    # numpy import jax in source code which causes test to fail for win
+    - python -c "import os; os.environ['KERAS_BACKEND'] = 'numpy'; import keras;"  # [not (win or s390x)]
+    - python -c "import os; os.environ['KERAS_BACKEND'] = 'jax'; import keras;"    # [not (win or s390x)]
+    - python -c "import os; os.environ['KERAS_BACKEND'] = 'torch'; import keras;"
     # the imports section is moved down here so that
     # we can set the backend to torch (tensorflow is
     # the default one, but not available at the moment
@@ -64,15 +76,9 @@ test:
     - python -c "import keras.datasets;"
     - python -c "import keras.layers;"
     - python -c "import keras.utils;"
+    - pytest integration_tests/torch_workflow_test.py
     - set KERAS_BACKEND=     # [win]
     - export KERAS_BACKEND=  # [not win]
-    # numpy is checked as backend in exports and contest (pytest tests configuration)
-    # although not listed in the README among the backends. We add a quick test here.
-    #
-    # numpy import jax in source code which causes test to fail for win
-    - python -c "import os; os.environ['KERAS_BACKEND'] = 'numpy'; import keras;"  # [not (win or s390x)]
-    - python -c "import os; os.environ['KERAS_BACKEND'] = 'jax'; import keras;"    # [not (win or s390x)]
-    - python -c "import os; os.environ['KERAS_BACKEND'] = 'torch'; import keras;"
 
 about:
   home: https://github.com/keras-team/keras

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,6 @@ requirements:
   run_constrained:
     # https://github.com/keras-team/keras/blob/v{{ version }}/requirements.txt
     - tensorflow >=2.17.0,<3.0a
-    # should be 0.4.23, but this will allow the jax[cuda] version to be installed (0.4.24)
     - jax >=0.4.23,<0.5.0a
     # pytorch should have >=2.1.0,<2.3.0 (GitHub issue #19602)
     # a simple >=2.1.0 lower bound is used with a patch.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,9 @@ build:
   skip: true  # [py<39]
 
 requirements:
+  build:
+    - m2-patch  # [win]
+    - patch     # [unix]
   host:
     - python
     - pip
@@ -46,7 +49,7 @@ requirements:
 test:
   requires:
     - pip
-    - jax  # [not win]
+    - jax  # [not (win or s390x)]
     - pytorch
   commands:
     - pip check
@@ -67,8 +70,8 @@ test:
     # although not listed in the README among the backends. We add a quick test here.
     #
     # numpy import jax in source code which causes test to fail for win
-    - python -c "import os; os.environ['KERAS_BACKEND'] = 'numpy'; import keras;"  # [not win]
-    - python -c "import os; os.environ['KERAS_BACKEND'] = 'jax'; import keras;"    # [not win]
+    - python -c "import os; os.environ['KERAS_BACKEND'] = 'numpy'; import keras;"  # [not (win or s390x)]
+    - python -c "import os; os.environ['KERAS_BACKEND'] = 'jax'; import keras;"    # [not (win or s390x)]
     - python -c "import os; os.environ['KERAS_BACKEND'] = 'torch'; import keras;"
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "keras" %}
-{% set version = "3.0.5" %}
+{% set version = "3.4.1" %}
 
 package:
   name: keras
@@ -7,19 +7,15 @@ package:
 
 source:
   url: https://github.com/keras-team/keras/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 0e23205f2d8f434ded17ca9efb116cdb7b6d19736e576456c28aea685a7f195f
+  sha256: fc36516fe8eb807480948385bc1ec3b6ebc64fdd963b645ff763d6e30ad72f66
+  patches:
+    # https://github.com/keras-team/keras/pull/19956
+    - patches/19956_pytorch_2.3_compatibility.patch
 
 build:
-  script_env:
-    # The default backend is tensorflow, but for this version of keras
-    # we do not have the correct version. We update keras and would like
-    # to offer at least a working backend: torch.
-    - KERAS_BACKEND=torch
   number: 0
-  script:
-    - {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-build-isolation -v
-  # skipping s390x since dm-tree and jax are not available
-  skip: true  # [py<39 or s390x]
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-build-isolation -v
+  skip: true  # [py<39]
 
 requirements:
   host:
@@ -34,24 +30,18 @@ requirements:
     - rich
     - namex
     - h5py
-    - dm-tree
+    - optree
     - ml_dtypes
-    # this is not mentioned in the upstream until version 3.3.0
-    # but it might have been a bug, because it is indeed used
-    # in this version as well at:
-    # https://github.com/keras-team/keras/blob/v3.0.5/keras/utils/torch_utils.py#L3
     - packaging
   run_constrained:
-    # as suggested in https://keras.io/getting_started/#tensorflow-compatibility
-    # tensorflow pinning expands ~=2.16.1
-    - tensorflow >=2.16.1,<2.17.0a
-    # should be 0.4.20, but this will allow the jax[cuda] version to be installed (0.4.24)
-    - jax >=0.4.20, <0.5.0a
-    # pytorch should have >=2.1.0,<2.2.0 (expanding ~=2.1.0) but in 
-    # https://github.com/keras-team/keras/blob/v3.0.5/requirements.txt#L6
-    # https://github.com/keras-team/keras/blob/v3.0.5/keras/utils/torch_utils.py#L156
-    # a simple >=2.1.0 lower bound is used.
+    # https://github.com/keras-team/keras/blob/v{{ version }}/requirements.txt
+    - tensorflow >=2.17.0,<3.0a
+    # should be 0.4.23, but this will allow the jax[cuda] version to be installed (0.4.24)
+    - jax >=0.4.23,<0.5.0a
+    # pytorch should have >=2.1.0,<2.3.0 (GitHub issue #19602)
+    # a simple >=2.1.0 lower bound is used with a patch.
     - pytorch >=2.1.0
+    - torchvision >=0.16.0
 
 test:
   requires:
@@ -82,7 +72,7 @@ test:
     - python -c "import os; os.environ['KERAS_BACKEND'] = 'torch'; import keras;"
 
 about:
-  home: https://github.com/fchollet/keras
+  home: https://github.com/keras-team/keras
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
@@ -93,7 +83,7 @@ about:
     vision, natural language processing, audio processing, timeseries forecasting, 
     recommender systems, etc.
   doc_url: https://keras.io/
-  dev_url: https://github.com/fchollet/keras
+  dev_url: https://github.com/keras-team/keras
 
 extra:
   recipe-maintainers:

--- a/recipe/patches/19956_pytorch_2.3_compatibility.patch
+++ b/recipe/patches/19956_pytorch_2.3_compatibility.patch
@@ -1,0 +1,73 @@
+From 0213c1b289c102879e8d8a41f2a4fee60ecdc370 Mon Sep 17 00:00:00 2001
+From: Hongyu Chiu <20734616+james77777778@users.noreply.github.com>
+Date: Fri, 5 Jul 2024 11:43:12 +0800
+Subject: [PATCH] Remove upperbound for torch version
+
+---
+ keras/src/backend/torch/core.py  | 41 +++++++++++++++++++++++++-------
+ requirements-jax-cuda.txt        |  2 +-
+ requirements-tensorflow-cuda.txt |  2 +-
+ requirements-torch-cuda.txt      |  4 ++--
+ requirements.txt                 |  2 +-
+ 5 files changed, 38 insertions(+), 13 deletions(-)
+
+diff --git a/keras/src/backend/torch/core.py b/keras/src/backend/torch/core.py
+index 1eecd751246..3a941fc46a4 100644
+--- a/keras/src/backend/torch/core.py
++++ b/keras/src/backend/torch/core.py
+@@ -15,6 +15,8 @@
+ from keras.src.backend.common.dtypes import result_type
+ from keras.src.backend.common.keras_tensor import KerasTensor
+ from keras.src.backend.common.stateless_scope import StatelessScope
++from keras.src.backend.common.stateless_scope import get_stateless_scope
++from keras.src.backend.common.stateless_scope import in_stateless_scope
+ from keras.src.backend.config import floatx
+ 
+ SUPPORTS_SPARSE_TENSORS = False
+@@ -129,15 +131,38 @@ def __array__(self, dtype=None):
+ 
+     @property
+     def value(self):
+-        value = super().value
+-        # Create and use a symbolic tensor stub in symbolic calls.
+-        if str(get_device()) == "meta" and str(value.device) != "meta":
+-            return torch.empty(
+-                size=value.shape,
+-                dtype=value.dtype,
+-                device="meta",
++        # We cannot chain super() here because it will fail TorchDynamo. The
++        # reason why is unclear.
++        def maybe_use_symbolic_tensor(value):
++            # Create and use a symbolic tensor stub in symbolic calls.
++            if str(get_device()) == "meta" and str(value.device) != "meta":
++                return torch.nn.Parameter(
++                    torch.empty(
++                        size=self._shape,
++                        dtype=to_torch_dtype(self._dtype),
++                        device="meta",
++                    ),
++                    requires_grad=self.trainable,
++                )
++            return value
++
++        if in_stateless_scope():
++            scope = get_stateless_scope()
++            value = scope.get_current_value(self)
++            if value is not None:
++                value = self._maybe_autocast(value)
++                return maybe_use_symbolic_tensor(value)
++        if self._value is None:
++            # Uninitialized variable. Return a placeholder.
++            # This is fine because it's only ever used
++            # in during shape inference / graph tracing
++            # (anything else would be a bug, to be fixed.)
++            value = self._maybe_autocast(
++                self._initializer(self._shape, dtype=self._dtype)
+             )
+-        return value
++        else:
++            value = self._maybe_autocast(self._value)
++        return maybe_use_symbolic_tensor(value)
+ 
+     @property
+     def trainable(self):


### PR DESCRIPTION
keras 3.4.1

**Destination channel:** main

### Links

- https://anaconda.atlassian.net/browse/PKG-5458
- https://github.com/keras-team/keras/tree/v3.4.1
- https://github.com/keras-team/keras/releases
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/optree-feedstock/pull/1

### Explanation of changes:

- We don't build jax with cuda yet. 
- No upper bound on pytorch thanks to the patch used.
